### PR TITLE
add parsimonious to requirements-dev.txt

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
 black
 pytest
 pre-commit
+parsimonious


### PR DESCRIPTION
it was missing from the requirements-dev.txt file
this caused tests to fail.