### PR TITLE
Feature/add inline flags

### DIFF
--- a/ke/__init__.py
+++ b/ke/__init__.py
@@ -58,6 +58,7 @@ def re(pattern: AnyStr, flavor: Optional[Flavor] = None) -> AnyStr:
     if _is_bytes_like(pattern):
         asm.InlineFlag.PATTERN_IS_BYTES_LIKE = True
         return _re(pattern.decode("ascii"), flavor).encode("ascii")  # type: ignore
+    asm.InlineFlag.PATTERN_IS_BYTES_LIKE = False
     assert isinstance(pattern, str)
     return _re(pattern, flavor)
 

--- a/ke/__init__.py
+++ b/ke/__init__.py
@@ -20,6 +20,8 @@ from re import (
     RegexFlag,
 )
 
+from ke import asm
+
 try:
     # added in Python 3.11
     from re import NOFLAG  # type: ignore
@@ -54,6 +56,7 @@ VERBOSE = X = 0
 def re(pattern: AnyStr, flavor: Optional[Flavor] = None) -> AnyStr:
     # TODO: LRU cache
     if _is_bytes_like(pattern):
+        asm.InlineFlag.PATTERN_IS_BYTES_LIKE = True
         return _re(pattern.decode("ascii"), flavor).encode("ascii")  # type: ignore
     assert isinstance(pattern, str)
     return _re(pattern, flavor)

--- a/ke/asm.py
+++ b/ke/asm.py
@@ -314,6 +314,11 @@ class InlineFlag(namedtuple("InlineFlag", ["flag_character", "name", "sub"]), As
     }
     UNSET = "unset"
     UNSETTABLE = set([I, M, S])
+    INCOMPATIBLE = set([A, L, U])
+    # Unicode flag CANNOT be used in bytes-like,
+    # locale_dependent can ONLY be used in bytes-like.
+    # This value is being set before compilation start.
+    PATTERN_IS_BYTES_LIKE = False
 
     def to_regex(self, flavor, capture_names, wrap=False):
         # Here we break the tree structure, using this specialized
@@ -339,20 +344,16 @@ class InlineFlag(namedtuple("InlineFlag", ["flag_character", "name", "sub"]), As
         setting = []
         unsetting = []
         flags = list(true_flags.values())
+        got_one_incompatible = False
         for flag in flags:
-            if flag.name not in [InlineFlag.UNSET, None]:
-                raise CompileError(
-                    f"Unrecognized token passed to flag: "
-                    f"{InlineFlag.regex_to_kleenexp[self.flag_character]} does not accept {self.name}"
-                )
+            self.validate_parameter_is_valid(flag)
+            self.validate_unset_flag_is_unsettable(flag)
+            self.validate_bytes_like_against_unicode_or_locale_only(flag)
+            got_one_incompatible = self.validate_no_incompatibles_together(
+                flag, got_one_incompatible
+            )
             if flag.name == InlineFlag.UNSET:
-                if flag.flag_character in InlineFlag.UNSETTABLE:
-                    unsetting.append(flag)
-                else:
-                    raise CompileError(
-                        f"Unsetting not supported for this flag: "
-                        f"{InlineFlag.regex_to_kleenexp[self.flag_character]}"
-                    )
+                unsetting.append(flag)
             else:
                 setting.append(flag)
 
@@ -363,6 +364,51 @@ class InlineFlag(namedtuple("InlineFlag", ["flag_character", "name", "sub"]), As
             else ""
         )
         return f"(?{setting_str}{unsetting_str}:{curr.to_regex(flavor, capture_names, wrap)})"
+
+    def validate_parameter_is_valid(self, flag):
+        if flag.name not in [InlineFlag.UNSET, None]:
+            raise CompileError(
+                f"Unrecognized token passed to flag: "
+                f"{InlineFlag.regex_to_kleenexp[self.flag_character]} does not accept {self.name}"
+            )
+
+    def validate_unset_flag_is_unsettable(self, flag):
+        if flag.name == InlineFlag.UNSET:
+            if flag.flag_character not in InlineFlag.UNSETTABLE:
+                raise CompileError(
+                    f"Unsetting not supported for this flag: "
+                    f"{InlineFlag.regex_to_kleenexp[self.flag_character]}"
+                )
+
+    def validate_bytes_like_against_unicode_or_locale_only(self, flag):
+        if InlineFlag.PATTERN_IS_BYTES_LIKE and flag.flag_character == InlineFlag.U:
+            raise CompileError(
+                f"Cannot use {InlineFlag.regex_to_kleenexp[self.flag_character]} flag "
+                f"with a bytes pattern"
+            )
+        if not InlineFlag.PATTERN_IS_BYTES_LIKE and flag.flag_character == InlineFlag.L:
+            raise CompileError(
+                f"Can only use {InlineFlag.regex_to_kleenexp[self.flag_character]} flag "
+                f"with a bytes pattern"
+            )
+
+    def validate_no_incompatibles_together(self, flag, got_one_incompatible):
+        """
+        Raises CompileError if found second incompatible, otherwise returns
+        true if found the first.
+        """
+        if flag.flag_character in InlineFlag.INCOMPATIBLE:
+            if got_one_incompatible:
+                raise CompileError(
+                    f"{InlineFlag.regex_to_kleenexp[InlineFlag.A]}, "
+                    f"{InlineFlag.regex_to_kleenexp[InlineFlag.L]} and "
+                    f"{InlineFlag.regex_to_kleenexp[InlineFlag.U]} are "
+                    f"incompatible and cannot be used in the same flag "
+                    f"setting expression"
+                )
+            else:
+                return True
+        return False
 
     def is_empty(self):
         return self.sub.is_empty()

--- a/ke/asm.py
+++ b/ke/asm.py
@@ -343,6 +343,11 @@ class InlineFlag(namedtuple("InlineFlag", ["flag_character", "name", "sub"]), As
         unsetting = []
         flags = list(true_flags.values())
         for flag in flags:
+            if flag.name not in [InlineFlag.UNSET, None]:
+                raise CompileError(
+                    f"Unrecognized token passed to flag: "
+                    f"{InlineFlag.regex_to_kleenexp[self.flag_character]} does not accept {self.name}"
+                )
             if flag.name == InlineFlag.UNSET:
                 if flag.flag_character in InlineFlag.UNSETTABLE:
                     unsetting.append(flag)

--- a/ke/asm.py
+++ b/ke/asm.py
@@ -344,7 +344,7 @@ class InlineFlag(namedtuple("InlineFlag", ["flag_character", "name", "sub"]), As
         flags = list(true_flags.values())
         for flag in flags:
             if flag.name == InlineFlag.UNSET:
-                if flag.name in InlineFlag.UNSETTABLE:
+                if flag.flag_character in InlineFlag.UNSETTABLE:
                     unsetting.append(flag)
                 else:
                     raise CompileError(

--- a/ke/asm.py
+++ b/ke/asm.py
@@ -300,7 +300,24 @@ class NegativeLookbehind(ParensSyntax):
 Lookbehind.INVERTED = NegativeLookbehind
 
 
-class InlineFlag(namedtuple("InlineFlag", ["name", "sub"]), Asm):
+class InlineFlag(namedtuple("InlineFlag", ["flag_character", "name", "sub"]), Asm):
+    A = "a"
+    L = "L"
+    U = "u"
+    I = "i"
+    M = "m"
+    S = "s"
+    regex_to_kleenexp = {
+        A: "ascii_only",
+        L: "locale_dependent",
+        U: "unicode",
+        I: "ignore_case",
+        M: "multiline",
+        S: "any_matches_all",
+    }
+    UNSET = "unset"
+    UNSETTABLE = set([I, M, S])
+
     def to_regex(self, flavor, capture_names, wrap=False):
         # Here we break the tree structure, using this specialized
         # function to create a flagging expression for the rest of
@@ -312,92 +329,41 @@ class InlineFlag(namedtuple("InlineFlag", ["name", "sub"]), Asm):
         return self.flag_sub_expression(flavor, capture_names, wrap)
 
     def flag_sub_expression(self, flavor, capture_names, wrap):
-        flags = [self]
+        # true_flags is a dictionary instead of a list to allow
+        # overriding previous flag declarations - for example:
+        # 'ignore_case ignore_case:unset' should give '(?-i:)'
+        # rather than '(?i-i:)' (this behaviour might be replaced
+        # with an error in the future).
+        true_flags = {self.flag_character: self}
         curr = self.sub
         while isinstance(curr, InlineFlag):
-            flags.append(curr)
+            true_flags[curr.flag_character] = curr
             curr = curr.sub
         setting = []
         unsetting = []
+        flags = list(true_flags.values())
         for flag in flags:
-            if isinstance(flag, UnsettingInlineFlag):
-                unsetting.append(flag)
+            if flag.name == InlineFlag.UNSET:
+                if flag.name in InlineFlag.UNSETTABLE:
+                    unsetting.append(flag)
+                else:
+                    raise CompileError(
+                        f"Unsetting not supported for this flag: "
+                        f"{InlineFlag.regex_to_kleenexp[self.flag_character]}"
+                    )
             else:
                 setting.append(flag)
-        self.check_turn_on_and_off_error(setting, unsetting)
 
-        setting_str = "".join([flag.FLAG for flag in setting])
+        setting_str = "".join([flag.flag_character for flag in setting])
         unsetting_str = (
-            "-".join([flag.FLAG for flag in unsetting]) if len(unsetting) > 0 else ""
+            "-" + "".join([flag.flag_character for flag in unsetting])
+            if len(unsetting) > 0
+            else ""
         )
-        return f"(?{setting_str}{unsetting_str}:{flags[-1].sub.to_regex(flavor, capture_names, wrap)})"
-
-    def check_turn_on_and_off_error(self, setting_flags, unsetting_flags):
-        map = {
-            IgnoreCase: 0,
-            UnsettingIgnoreCase: 0,
-            Multiline: 1,
-            UnsettingMultiline: 1,
-            AnyMatchesAll: 2,
-            UnsettingAnyMatchesAll: 2,
-            # not unsettable, set out of range:
-            LocaleDependent: 3,
-            Unicode: 3,
-            AsciiOnly: 3,
-        }
-        hits = [False, False, False, None]
-        for flag in setting_flags:
-            flag_type = type(flag)
-            hits[map[flag_type]] = True
-        for flag in unsetting_flags:
-            flag_type = type(flag)
-            if hits[map[flag_type]]:
-                raise CompileError(
-                    f"Flag of type {str(flag_type)} was set and unset simultaneously."
-                )
+        return f"(?{setting_str}{unsetting_str}:{curr.to_regex(flavor, capture_names, wrap)})"
 
     def is_empty(self):
         return self.sub.is_empty()
-
-
-class LocaleDependent(InlineFlag):
-    FLAG = "L"
-
-
-class Unicode(InlineFlag):
-    FLAG = "u"
-
-
-class AsciiOnly(InlineFlag):
-    FLAG = "a"
-
-
-class IgnoreCase(InlineFlag):
-    FLAG = "i"
-
-
-class Multiline(InlineFlag):
-    FLAG = "m"
-
-
-class AnyMatchesAll(InlineFlag):
-    FLAG = "i"
-
-
-class UnsettingInlineFlag(InlineFlag):
-    UNSET = ":unset"
-
-
-class UnsettingIgnoreCase(InlineFlag):
-    FLAG = IgnoreCase.FLAG
-
-
-class UnsettingMultiline(InlineFlag):
-    FLAG = Multiline.FLAG
-
-
-class UnsettingAnyMatchesAll(InlineFlag):
-    FLAG = AnyMatchesAll.FLAG
 
 
 class Setting(namedtuple("Setting", ["setting", "sub"]), Asm):

--- a/ke/asm.py
+++ b/ke/asm.py
@@ -386,12 +386,12 @@ class InlineFlag(namedtuple("InlineFlag", ["flag_character", "name", "sub"]), As
     def validate_bytes_like_against_unicode_or_locale_only(self, flag):
         if InlineFlag.PATTERN_IS_BYTES_LIKE and flag.flag_character == InlineFlag.U:
             raise CompileError(
-                f"Cannot use {InlineFlag.regex_to_kleenexp[self.flag_character]} flag "
+                f"Cannot use {InlineFlag.regex_to_kleenexp[flag.flag_character]} flag "
                 f"with a bytes pattern"
             )
         if not InlineFlag.PATTERN_IS_BYTES_LIKE and flag.flag_character == InlineFlag.L:
             raise CompileError(
-                f"Can only use {InlineFlag.regex_to_kleenexp[self.flag_character]} flag "
+                f"Can only use {InlineFlag.regex_to_kleenexp[flag.flag_character]} flag "
                 f"with a bytes pattern"
             )
 

--- a/ke/asm.py
+++ b/ke/asm.py
@@ -383,12 +383,12 @@ class InlineFlag(namedtuple("InlineFlag", ["flag_character", "name", "sub"]), As
     def validate_bytes_like_against_unicode_or_locale_only(self, flag):
         if InlineFlag.PATTERN_IS_BYTES_LIKE and flag.flag_character == InlineFlag.U:
             raise CompileError(
-                f"Cannot use {InlineFlag.regex_to_kleenexp[self.flag_character]} flag "
+                f"Cannot use {InlineFlag.regex_to_kleenexp[flag.flag_character]} flag "
                 f"with a bytes pattern"
             )
         if not InlineFlag.PATTERN_IS_BYTES_LIKE and flag.flag_character == InlineFlag.L:
             raise CompileError(
-                f"Can only use {InlineFlag.regex_to_kleenexp[self.flag_character]} flag "
+                f"Can only use {InlineFlag.regex_to_kleenexp[flag.flag_character]} flag "
                 f"with a bytes pattern"
             )
 

--- a/ke/asm.py
+++ b/ke/asm.py
@@ -341,7 +341,7 @@ class InlineFlag(namedtuple("InlineFlag", ["flag_character", "name", "sub"]), As
         flags = list(true_flags.values())
         for flag in flags:
             if flag.name == InlineFlag.UNSET:
-                if flag.name in InlineFlag.UNSETTABLE:
+                if flag.flag_character in InlineFlag.UNSETTABLE:
                     unsetting.append(flag)
                 else:
                     raise CompileError(

--- a/ke/asm.py
+++ b/ke/asm.py
@@ -317,6 +317,11 @@ class InlineFlag(namedtuple("InlineFlag", ["flag_character", "name", "sub"]), As
     }
     UNSET = "unset"
     UNSETTABLE = set([I, M, S])
+    INCOMPATIBLE = set([A, L, U])
+    # Unicode flag CANNOT be used in bytes-like,
+    # locale_dependent can ONLY be used in bytes-like.
+    # This value is being set before compilation start.
+    PATTERN_IS_BYTES_LIKE = False
 
     def to_regex(self, flavor, capture_names, wrap=False):
         # Here we break the tree structure, using this specialized
@@ -342,20 +347,16 @@ class InlineFlag(namedtuple("InlineFlag", ["flag_character", "name", "sub"]), As
         setting = []
         unsetting = []
         flags = list(true_flags.values())
+        got_one_incompatible = False
         for flag in flags:
-            if flag.name not in [InlineFlag.UNSET, None]:
-                raise CompileError(
-                    f"Unrecognized token passed to flag: "
-                    f"{InlineFlag.regex_to_kleenexp[self.flag_character]} does not accept {self.name}"
-                )
+            self.validate_parameter_is_valid(flag)
+            self.validate_unset_flag_is_unsettable(flag)
+            self.validate_bytes_like_against_unicode_or_locale_only(flag)
+            got_one_incompatible = self.validate_no_incompatibles_together(
+                flag, got_one_incompatible
+            )
             if flag.name == InlineFlag.UNSET:
-                if flag.flag_character in InlineFlag.UNSETTABLE:
-                    unsetting.append(flag)
-                else:
-                    raise CompileError(
-                        f"Unsetting not supported for this flag: "
-                        f"{InlineFlag.regex_to_kleenexp[self.flag_character]}"
-                    )
+                unsetting.append(flag)
             else:
                 setting.append(flag)
 
@@ -366,6 +367,51 @@ class InlineFlag(namedtuple("InlineFlag", ["flag_character", "name", "sub"]), As
             else ""
         )
         return f"(?{setting_str}{unsetting_str}:{curr.to_regex(flavor, capture_names, wrap)})"
+
+    def validate_parameter_is_valid(self, flag):
+        if flag.name not in [InlineFlag.UNSET, None]:
+            raise CompileError(
+                f"Unrecognized token passed to flag: "
+                f"{InlineFlag.regex_to_kleenexp[self.flag_character]} does not accept {self.name}"
+            )
+
+    def validate_unset_flag_is_unsettable(self, flag):
+        if flag.name == InlineFlag.UNSET:
+            if flag.flag_character not in InlineFlag.UNSETTABLE:
+                raise CompileError(
+                    f"Unsetting not supported for this flag: "
+                    f"{InlineFlag.regex_to_kleenexp[self.flag_character]}"
+                )
+
+    def validate_bytes_like_against_unicode_or_locale_only(self, flag):
+        if InlineFlag.PATTERN_IS_BYTES_LIKE and flag.flag_character == InlineFlag.U:
+            raise CompileError(
+                f"Cannot use {InlineFlag.regex_to_kleenexp[self.flag_character]} flag "
+                f"with a bytes pattern"
+            )
+        if not InlineFlag.PATTERN_IS_BYTES_LIKE and flag.flag_character == InlineFlag.L:
+            raise CompileError(
+                f"Can only use {InlineFlag.regex_to_kleenexp[self.flag_character]} flag "
+                f"with a bytes pattern"
+            )
+
+    def validate_no_incompatibles_together(self, flag, got_one_incompatible):
+        """
+        Raises CompileError if found second incompatible, otherwise returns
+        true if found the first.
+        """
+        if flag.flag_character in InlineFlag.INCOMPATIBLE:
+            if got_one_incompatible:
+                raise CompileError(
+                    f"{InlineFlag.regex_to_kleenexp[InlineFlag.A]}, "
+                    f"{InlineFlag.regex_to_kleenexp[InlineFlag.L]} and "
+                    f"{InlineFlag.regex_to_kleenexp[InlineFlag.U]} are "
+                    f"incompatible and cannot be used in the same flag "
+                    f"setting expression"
+                )
+            else:
+                return True
+        return False
 
     def is_empty(self):
         return self.sub.is_empty()

--- a/ke/asm.py
+++ b/ke/asm.py
@@ -225,10 +225,6 @@ class Repeat(namedtuple("Repeat", ["name"]), Asm):
                 )
         return self.maybe_wrap(wrap, rf"\{index}")
 
-    def 
-    (self):
-        return False
-
 
 class Capture(namedtuple("Capture", ["name", "sub"]), Asm):
     def to_regex(self, flavor, capture_names, wrap=False):
@@ -299,6 +295,106 @@ class NegativeLookbehind(ParensSyntax):
 
 
 Lookbehind.INVERTED = NegativeLookbehind
+
+
+class InlineFlag(namedtuple("InlineFlag", ["name", "sub"]), Asm):
+    def to_regex(self, flavor, capture_names, wrap=False):
+        # Here we break the tree structure, using this specialized
+        # function to create a flagging expression for the rest of
+        # the subtree. The only flag in a flagging sequence that
+        # reaches the to_regex() method is the first one in the
+        # sequence (there may be other sequences). This is necessary
+        # because the parenthesis wrapping and regex legality are
+        # dependent on the whole flagging expression.
+        return self.flag_sub_expression(flavor, capture_names, wrap)
+
+    def flag_sub_expression(self, flavor, capture_names, wrap):
+        flags = [self]
+        curr = self.sub
+        while isinstance(curr, InlineFlag):
+            flags.append(curr)
+            curr = curr.sub
+        setting = []
+        unsetting = []
+        for flag in flags:
+            if isinstance(flag, UnsettingInlineFlag):
+                unsetting.append(flag)
+            else:
+                setting.append(flag)
+        self.check_turn_on_and_off_error(setting, unsetting)
+
+        setting_str = "".join([flag.FLAG for flag in setting])
+        unsetting_str = (
+            "-".join([flag.FLAG for flag in unsetting]) if len(unsetting) > 0 else ""
+        )
+        return f"(?{setting_str}{unsetting_str}:{flags[-1].sub.to_regex(flavor, capture_names, wrap)})"
+
+    def check_turn_on_and_off_error(self, setting_flags, unsetting_flags):
+        map = {
+            IgnoreCase: 0,
+            UnsettingIgnoreCase: 0,
+            Multiline: 1,
+            UnsettingMultiline: 1,
+            AnyMatchesAll: 2,
+            UnsettingAnyMatchesAll: 2,
+            # not unsettable, set out of range:
+            LocaleDependent: 3,
+            Unicode: 3,
+            AsciiOnly: 3,
+        }
+        hits = [False, False, False, None]
+        for flag in setting_flags:
+            flag_type = type(flag)
+            hits[map[flag_type]] = True
+        for flag in unsetting_flags:
+            flag_type = type(flag)
+            if hits[map[flag_type]]:
+                raise CompileError(
+                    f"Flag of type {str(flag_type)} was set and unset simultaneously."
+                )
+
+    def is_empty(self):
+        return self.sub.is_empty()
+
+
+class LocaleDependent(InlineFlag):
+    FLAG = "L"
+
+
+class Unicode(InlineFlag):
+    FLAG = "u"
+
+
+class AsciiOnly(InlineFlag):
+    FLAG = "a"
+
+
+class IgnoreCase(InlineFlag):
+    FLAG = "i"
+
+
+class Multiline(InlineFlag):
+    FLAG = "m"
+
+
+class AnyMatchesAll(InlineFlag):
+    FLAG = "i"
+
+
+class UnsettingInlineFlag(InlineFlag):
+    UNSET = ":unset"
+
+
+class UnsettingIgnoreCase(InlineFlag):
+    FLAG = IgnoreCase.FLAG
+
+
+class UnsettingMultiline(InlineFlag):
+    FLAG = Multiline.FLAG
+
+
+class UnsettingAnyMatchesAll(InlineFlag):
+    FLAG = AnyMatchesAll.FLAG
 
 
 class Setting(namedtuple("Setting", ["setting", "sub"]), Asm):

--- a/ke/asm.py
+++ b/ke/asm.py
@@ -340,6 +340,11 @@ class InlineFlag(namedtuple("InlineFlag", ["flag_character", "name", "sub"]), As
         unsetting = []
         flags = list(true_flags.values())
         for flag in flags:
+            if flag.name not in [InlineFlag.UNSET, None]:
+                raise CompileError(
+                    f"Unrecognized token passed to flag: "
+                    f"{InlineFlag.regex_to_kleenexp[self.flag_character]} does not accept {self.name}"
+                )
             if flag.name == InlineFlag.UNSET:
                 if flag.flag_character in InlineFlag.UNSETTABLE:
                     unsetting.append(flag)

--- a/ke/compiler.py
+++ b/ke/compiler.py
@@ -162,6 +162,22 @@ lookahead la""".splitlines():
     long, short = names.split()
     builtin_operators[short] = builtin_operators[long]
 
+inline_flags = {
+    "ascii_only": asm.AsciiOnly,
+    "locale_dependent": asm.LocaleDependent,
+    "unicode": asm.Unicode,
+    "ignore_case": asm.IgnoreCase,
+    "multiline": asm.Multiline,
+    "any_matches_all": asm.AnyMatchesAll,
+}
+builtin_operators.update(inline_flags)
+unsetting_inline_flags = {
+    "ignore_case" + asm.UnsettingInlineFlag.UNSET: asm.IgnoreCase,
+    "multiline" + asm.UnsettingInlineFlag.UNSET: asm.Multiline,
+    "any_matches_all" + asm.UnsettingInlineFlag.UNSET: asm.AnyMatchesAll,
+}
+builtin_operators.update(unsetting_inline_flags)
+
 
 def compile(ast):
     macros = dict(builtin_macros)

--- a/ke/compiler.py
+++ b/ke/compiler.py
@@ -163,20 +163,14 @@ lookahead la""".splitlines():
     builtin_operators[short] = builtin_operators[long]
 
 inline_flags = {
-    "ascii_only": asm.AsciiOnly,
-    "locale_dependent": asm.LocaleDependent,
-    "unicode": asm.Unicode,
-    "ignore_case": asm.IgnoreCase,
-    "multiline": asm.Multiline,
-    "any_matches_all": asm.AnyMatchesAll,
+    asm.InlineFlag.regex_to_kleenexp[asm.InlineFlag.A]: asm.InlineFlag.A,
+    asm.InlineFlag.regex_to_kleenexp[asm.InlineFlag.L]: asm.InlineFlag.L,
+    asm.InlineFlag.regex_to_kleenexp[asm.InlineFlag.U]: asm.InlineFlag.U,
+    asm.InlineFlag.regex_to_kleenexp[asm.InlineFlag.I]: asm.InlineFlag.I,
+    asm.InlineFlag.regex_to_kleenexp[asm.InlineFlag.M]: asm.InlineFlag.M,
+    asm.InlineFlag.regex_to_kleenexp[asm.InlineFlag.S]: asm.InlineFlag.S,
 }
 builtin_operators.update(inline_flags)
-unsetting_inline_flags = {
-    "ignore_case" + asm.UnsettingInlineFlag.UNSET: asm.IgnoreCase,
-    "multiline" + asm.UnsettingInlineFlag.UNSET: asm.Multiline,
-    "any_matches_all" + asm.UnsettingInlineFlag.UNSET: asm.AnyMatchesAll,
-}
-builtin_operators.update(unsetting_inline_flags)
 
 
 def compile(ast):
@@ -273,6 +267,8 @@ def compile_operator(o, macros):
             max = int(max)
 
         return asm.Multiple(min, max, get_greediness_by_name_of_operator(o.name), sub)
+    if o.op_name in inline_flags:
+        return asm.InlineFlag(inline_flags[o.op_name], o.name, sub)
     if o.op_name not in builtin_operators:
         raise CompileError("Operator %s does not exist" % o.op_name)
     return builtin_operators[o.op_name](o.name, sub)

--- a/ke/tests/test_api.py
+++ b/ke/tests/test_api.py
@@ -680,10 +680,11 @@ def test_inline_flags():
     assert ke.match("[ignore_case 'A']", "a")
     assert not ke.match("[ignore_case [ignore_case:unset 'A']]", "a")
     assert ke.findall("[multiline #start_line 'a']", "a\na") == ["a", "a"]
+    # this is weird, but corresponds to regex
     assert ke.findall("[multiline #start_line [multiline:unset 'a']]", "a\na") == [
         "a",
         "a",
-    ]  # this is weird, but corresponds to regex
+    ]
     assert ke.findall("[multiline [multiline:unset #start_line  'a']]", "a\na") == ["a"]
     assert ke.match("[any_matches_all #any]", "\n")
     assert ke.match("[#digit]", "\u0660")

--- a/ke/tests/test_api.py
+++ b/ke/tests/test_api.py
@@ -674,3 +674,37 @@ def test_no_whitespace():
     ) == ke.re(
         "Hello. My name is [capture:name #tmp ' ' #tmp #tmp=[#uppercase [1+ #lowercase]]]. You killed my ['Father' | 'Mother' | 'Son' | 'Daughter' | 'Dog' | 'Hamster']. Prepare to die."
     )
+
+
+def test_inline_flags():
+    assert ke.match("[ignore_case 'A']", "a")
+    assert not ke.match("[ignore_case [ignore_case:unset 'A']]", "a")
+    assert ke.findall("[multiline #start_line 'a']", "a\na") == ["a", "a"]
+    assert ke.findall("[multiline #start_line [multiline:unset 'a']]", "a\na") == [
+        "a",
+        "a",
+    ]  # this is weird, but corresponds to regex
+    assert ke.findall("[multiline [multiline:unset #start_line  'a']]", "a\na") == ["a"]
+    assert ke.match("[any_matches_all #any]", "\n")
+    assert ke.match("[#digit]", "\u0660")
+    assert not ke.match("[ascii_only #digit]", "\u0660")
+    assert ke.re("[unicode 'test']") == r"(?u:test)"
+    assert ke.re(b"[locale_dependent 'test']") == b"(?L:test)"
+    with pytest.raises(re.error):
+        ke.re("[locale_dependent 'test']")
+    with pytest.raises(re.error):
+        ke.re(b"[locale_dependent ascii_only 'test']")
+    with pytest.raises(re.error):
+        ke.re(b"[unicode 'test']")
+    with pytest.raises(re.error):
+        ke.re("[unicode ascii_only 'test']")
+    assert ke.findall(
+        "[ignore_case multiline any_matches_all #start_line 'a']", "A\nA\nA"
+    ) == ["A", "A", "A"]
+    assert ke.findall(
+        "[ignore_case [multiline [any_matches_all #start_line 'a']]]", "A\nA\nA"
+    ) == ["A", "A", "A"]
+    assert ke.findall("[ignore_case [any_matches_all 'a'#any]]", "A\nA\nA") == [
+        "A\n",
+        "A\n",
+    ]

--- a/ke/tests/test_api.py
+++ b/ke/tests/test_api.py
@@ -705,7 +705,9 @@ def test_inline_flags():
     assert ke.findall(
         "[ignore_case [multiline [any_matches_all #start_line 'a']]]", "A\nA\nA"
     ) == ["A", "A", "A"]
-    assert ke.findall("[ignore_case [any_matches_all 'a'#any]]", "A\nA\nA") == [
-        "A\n",
-        "A\n",
+    assert ke.findall(
+        "AAA[ignore_case [any_matches_all 'a'#any]'a']AA", "AAAA\naAAAAAA\nAAAaAAA\nAAA"
+    ) == [
+        "AAAA\naAA",
+        "AAAA\nAAA",
     ]

--- a/ke/tests/test_asm.py
+++ b/ke/tests/test_asm.py
@@ -152,6 +152,10 @@ def test_inline_flags():
         assemble(InlineFlag("L", "unset", Literal("test")))
     with pytest.raises(CompileError):
         assemble(InlineFlag("u", "unset", Literal("test")))
+    with pytest.raises(CompileError):
+        assemble(InlineFlag("i", "garbage-nothing", Literal("test")))
+    with pytest.raises(CompileError):
+        assemble(InlineFlag("i", "", Literal("test")))
 
     assert (
         assemble(

--- a/ke/tests/test_asm.py
+++ b/ke/tests/test_asm.py
@@ -156,44 +156,46 @@ def test_inline_flags():
         assemble(InlineFlag("i", "garbage-nothing", Literal("test")))
     with pytest.raises(CompileError):
         assemble(InlineFlag("i", "", Literal("test")))
+    with pytest.raises(CompileError):
+        assemble(InlineFlag("a", None, InlineFlag("L", None, Literal("test"))))
+    with pytest.raises(CompileError):
+        assemble(InlineFlag("L", None, InlineFlag("u", None, Literal("test"))))
+    with pytest.raises(CompileError):
+        assemble(InlineFlag("u", None, InlineFlag("a", None, Literal("test"))))
+    assert (
+        assemble(InlineFlag("L", None, InlineFlag("L", None, Literal("test"))))
+        == r"(?L:test)"
+    )
 
     assert (
         assemble(
             InlineFlag(
-                "a",
+                "u",
                 None,
                 InlineFlag(
-                    "L",
+                    "i",
                     None,
                     InlineFlag(
-                        "u",
+                        "m",
                         None,
                         InlineFlag(
-                            "i",
+                            "s",
                             None,
                             InlineFlag(
-                                "m",
-                                None,
+                                "i",
+                                "unset",
                                 InlineFlag(
-                                    "s",
-                                    None,
-                                    InlineFlag(
-                                        "i",
-                                        "unset",
-                                        InlineFlag(
-                                            "m",
-                                            "unset",
-                                            InlineFlag("s", "unset", Literal("test")),
-                                        ),
-                                    ),
+                                    "m",
+                                    "unset",
+                                    InlineFlag("s", "unset", Literal("test")),
                                 ),
                             ),
                         ),
                     ),
                 ),
-            )
+            ),
         )
-        == r"(?aLu-ims:test)"
+        == r"(?u-ims:test)"
     )
 
     assert (
@@ -205,32 +207,24 @@ def test_inline_flags():
                     "a",
                     None,
                     InlineFlag(
-                        "L",
-                        None,
+                        "m",
+                        "unset",
                         InlineFlag(
-                            "u",
+                            "m",
                             None,
                             InlineFlag(
-                                "m",
-                                "unset",
+                                "i",
+                                None,
                                 InlineFlag(
-                                    "m",
+                                    "s",
                                     None,
-                                    InlineFlag(
-                                        "i",
-                                        None,
-                                        InlineFlag(
-                                            "s",
-                                            None,
-                                            InlineFlag("s", "unset", Literal("test")),
-                                        ),
-                                    ),
+                                    InlineFlag("s", "unset", Literal("test")),
                                 ),
                             ),
                         ),
                     ),
                 ),
-            )
+            ),
         )
-        == r"(?iaLum-s:test)"
+        == r"(?iam-s:test)"
     )

--- a/ke/tests/test_asm.py
+++ b/ke/tests/test_asm.py
@@ -138,6 +138,14 @@ def test_inline_flags():
     assert assemble(InlineFlag("i", "unset", Literal("test"))) == r"(?-i:test)"
     assert assemble(InlineFlag("m", "unset", Literal("test"))) == r"(?-m:test)"
     assert assemble(InlineFlag("s", "unset", Literal("test"))) == r"(?-s:test)"
+    assert (
+        assemble(InlineFlag("s", None, InlineFlag("s", None, Literal("test"))))
+        == r"(?s:test)"
+    )
+    assert (
+        assemble(InlineFlag("s", "unset", InlineFlag("s", "unset", Literal("test"))))
+        == r"(?-s:test)"
+    )
     with pytest.raises(CompileError):
         assemble(InlineFlag("a", "unset", Literal("test")))
     with pytest.raises(CompileError):

--- a/ke/tests/test_asm.py
+++ b/ke/tests/test_asm.py
@@ -129,8 +129,11 @@ def test_boundary():
 
 
 def test_inline_flags():
+    save_PATTERN_IS_BYTES_LIKE = InlineFlag.PATTERN_IS_BYTES_LIKE
     assert assemble(InlineFlag("a", None, Literal("test"))) == r"(?a:test)"
+    InlineFlag.PATTERN_IS_BYTES_LIKE = True
     assert assemble(InlineFlag("L", None, Literal("test"))) == r"(?L:test)"
+    InlineFlag.PATTERN_IS_BYTES_LIKE = False
     assert assemble(InlineFlag("u", None, Literal("test"))) == r"(?u:test)"
     assert assemble(InlineFlag("i", None, Literal("test"))) == r"(?i:test)"
     assert assemble(InlineFlag("m", None, Literal("test"))) == r"(?m:test)"
@@ -148,8 +151,10 @@ def test_inline_flags():
     )
     with pytest.raises(CompileError):
         assemble(InlineFlag("a", "unset", Literal("test")))
+    InlineFlag.PATTERN_IS_BYTES_LIKE = True
     with pytest.raises(CompileError):
         assemble(InlineFlag("L", "unset", Literal("test")))
+    InlineFlag.PATTERN_IS_BYTES_LIKE = False
     with pytest.raises(CompileError):
         assemble(InlineFlag("u", "unset", Literal("test")))
     with pytest.raises(CompileError):
@@ -162,11 +167,13 @@ def test_inline_flags():
         assemble(InlineFlag("L", None, InlineFlag("u", None, Literal("test"))))
     with pytest.raises(CompileError):
         assemble(InlineFlag("u", None, InlineFlag("a", None, Literal("test"))))
+    InlineFlag.PATTERN_IS_BYTES_LIKE = True
     assert (
         assemble(InlineFlag("L", None, InlineFlag("L", None, Literal("test"))))
         == r"(?L:test)"
     )
 
+    InlineFlag.PATTERN_IS_BYTES_LIKE = False
     assert (
         assemble(
             InlineFlag(
@@ -228,3 +235,4 @@ def test_inline_flags():
         )
         == r"(?iam-s:test)"
     )
+    InlineFlag.PATTERN_IS_BYTES_LIKE = save_PATTERN_IS_BYTES_LIKE


### PR DESCRIPTION
These 3 flags are incompatible in regex: [ASCII, UNICODE, LOCALE]. This roughly means that the inline flags [a,u,L] cannot be used together in  a same-nested-level flagging. When a when one of these flags is nested deeper than another one, it will override the outer flag for the substring it affects.
There are two problems with this implementation: 
Python regex allows this behavior - ```(?i:)``` - while this PR does not allow ```[ignore_case]``` or ```[ignore_case '']``` (the last one is easy to fix with half a line in compiler.py line:255). However, I don't hate this and think it's probably better behavior.
The bigger problem is the fact that ```(?u:(?a:somestring))``` is allowed in regex, with the ASCII overriding the UNICODE flag (same with all examples of the incompatible flags [ASCII, UNICODE, LOCALE] together). 
Here, this is not a valid expression - ```[unicode [ascii_only 'somestring']]``` - because nesting depth of an expression is not kept in the parsing flow. Note however, this is kind of generalization of the first problem - the concat operator makes it possible to write this ```[unicode [ascii_only 'somestring']'anything']```, so the expression is invalid only if the outer flag is not operating on anything, but in this case - ```[unicode [ascii_only 'somestring']]``` - it seems less obvious to realize what's the problem when translating from regex to kleenexp. 
The 3 solutions I can think of for this are:
 a. Add a nesting depth value to nodes when parsing - I don't want to do, because I don't understand enough of the parsing and this seems a major change.
 b. Add this to a collection of 'problematic behaviors' somewhere.
 c. Remove the unicode and locale_dependent flags completely from kleenexp - kind of an overreaction in my opinion.
 d. Ignore, which is what I'm doing now and is probably an inferior solution to b.